### PR TITLE
Update nalgebra dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ egui = "0.18"
 egui_glium = "0.18"
 glium = "0.31"
 image = "0.24"
-nalgebra = "0.21"
+nalgebra = "0.27"
 numeric-algs = "0.5"
 
 [features]


### PR DESCRIPTION
Hello! I found this simulator from the youtube vids, which were excellent. I was excited play with it and even better to find out it's written in rust. I thought the ui looked like egui in the videos, and it is!

I was getting a build error about `numeric_algs::State::Derivative` trait not being implemented for a specific `VectorN` type. It looks like you just bumped `nalgebra` to 0.27 in `numeric-algs` which was causing a clash with the types from `nalgebra` 0.21. I just bumped it in Cargo.toml here and it built fine.

I'm looking forward to playing with this! Thanks for creating and publishing it!